### PR TITLE
fix: Update tsparticles to v3 API and resolve build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tsparticles/react": "^3.3.0",
+    "@tsparticles/slim": "^3.3.0",
     "@emailjs/browser": "^4.1.0",
     "@hookform/resolvers": "^5.0.1",
     "@mailchimp/mailchimp_marketing": "^3.0.80",
@@ -23,10 +25,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.56.4",
     "react-hot-toast": "^2.4.1",
-    "react-tsparticles": "^2.12.2",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "tsparticles-slim": "^2.12.0",
     "zod": "^3.25.7"
   },
   "devDependencies": {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,43 +1,36 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ArrowRight, Info } from 'lucide-react'; // Removed Activity
+import React, { useCallback } from 'react'; // Removed useEffect and useState
+import { ArrowRight, Info } from 'lucide-react';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import Particles, { initParticlesEngine } from "react-tsparticles";
-import { loadSlim } from "tsparticles-slim";
-import { particlesConfig } from "@/lib/particles-config"; // Import the configuration
-import type { Engine } from "tsparticles-engine"; // Correct type for engine
+import Particles from "@tsparticles/react"; // Updated import
+import { loadSlim } from "@tsparticles/slim"; // Updated import
+import { particlesConfig } from "@/lib/particles-config";
+import type { Engine, Container } from "@tsparticles/engine"; // Engine and Container types
 
 export default function Hero() {
-  const [init, setInit] = useState(false);
+  // Removed init state and useEffect for initParticlesEngine
 
-  // this should be run only once per application lifetime
-  useEffect(() => {
-    initParticlesEngine(async (engine: Engine) => { // Explicitly type engine
-      // you can initiate the tsParticles instance (engine) here, adding custom shapes or presets
-      // this loads the tsparticles package bundle, it's a bare bundle
-      // adding an empty bundle will load the default options, which are static particles with no interactions
-      // CAVEAT: ISourceOptions is not compatible with the slim bundle, using ISourceOptions from "tsparticles-engine"
-      await loadSlim(engine);
-      // await loadBasic(engine); // if you used "tsparticles"
-    }).then(() => {
-      setInit(true);
-    });
+  const particlesInit = useCallback(async (engine: Engine) => {
+    // console.log(engine); // For debugging if needed
+    // loads the tsparticles package bundle, it's a bare bundle
+    // adding an empty bundle will load the default options, which are static particles with no interactions
+    await loadSlim(engine);
   }, []);
 
-  const particlesLoaded = useCallback(async (container: any) => { // `container` can be typed if needed
-    await console.log("Particles loaded", container);
+  const particlesLoaded = useCallback(async (container?: Container) => { // Updated prop name and type
+    // await console.log("Particles loaded", container); // For debugging if needed
   }, []);
   
   return (
     <div className="relative min-h-screen flex items-center justify-center text-center overflow-hidden py-12 md:py-24">
-      {init && (
-        <Particles
-          id="tsparticles"
-          particlesLoaded={particlesLoaded}
-          options={particlesConfig}
-          className="absolute inset-0 -z-10" // Ensure particles are in the background
-        />
-      )}
+      {/* Particles component now directly uses init and loaded props */}
+      <Particles
+        id="tsparticles"
+        init={particlesInit}
+        loaded={particlesLoaded}
+        options={particlesConfig}
+        className="absolute inset-0 -z-10" // Ensure particles are in the background
+      />
       
       <div className="container mx-auto px-6 relative z-10"> {/* Content must have higher z-index */}
         {/* Increased max-width for a wider text column, centered text */}

--- a/src/lib/particles-config.ts
+++ b/src/lib/particles-config.ts
@@ -1,6 +1,6 @@
-import type { ISourceOptions } from "tsparticles-slim";
+import type { IOptions } from "@tsparticles/engine"; // Updated import for v3 types
 
-export const particlesConfig: ISourceOptions = {
+export const particlesConfig: IOptions = { // Updated type to IOptions
   autoPlay: true,
   background: {
     color: {


### PR DESCRIPTION
This commit addresses a Vercel build failure caused by an incorrect API usage for the `react-tsparticles` library. The library was updated from v2 (`react-tsparticles`, `tsparticles-slim`) to v3 (`@tsparticles/react`, `@tsparticles/slim`) to resolve this.

Key changes:

1.  **Package Updates:**
    *   Uninstalled old `react-tsparticles` and `tsparticles-slim` packages.
    *   Installed new scoped packages: `@tsparticles/react` (v3.3.0) and
        `@tsparticles/slim` (v3.3.0).
    *   `package.json` was updated to reflect these dependencies.

2.  **API Usage in `Hero.tsx`:**
    *   Modified `src/components/Hero.tsx` to use the correct v3 API for
        `@tsparticles/react`.
    *   Removed the explicit call to the old `initParticlesEngine` function,
        which was causing the export error.
    *   The Particles component now uses the `init` prop to correctly
        initialize the engine and load the `slim` preset.
    *   Updated import paths for the new scoped packages.

3.  **Configuration Typing:**
    *   Updated `src/lib/particles-config.ts` to use `IOptions` type from
        `@tsparticles/engine` for better type safety with v3.

This resolves the ""initParticlesEngine" is not exported" build error and ensures the particle animations use the current and supported version of the tsparticles library.